### PR TITLE
fix EXT-X-MEDIA DEFAULT=yes wrt AUTOSELECT

### DIFF
--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -238,9 +238,7 @@ impl ExtXMediaBuilder {
             ).to_string());
         }
 
-        if self.is_default.unwrap_or(false)
-            && self.is_autoselect.is_some()
-            && !self.is_autoselect.unwrap()
+        if self.is_default.unwrap_or(false) && self.is_autoselect.map_or(false, |b| !b)
         {
             return Err(Error::custom(format!(
                 "If `DEFAULT` is true, `AUTOSELECT` has to be true too, if present. Default: {:?}, Autoselect: {:?}!",

--- a/src/tags/master_playlist/media.rs
+++ b/src/tags/master_playlist/media.rs
@@ -238,9 +238,12 @@ impl ExtXMediaBuilder {
             ).to_string());
         }
 
-        if self.is_default.unwrap_or(false) && !self.is_autoselect.unwrap_or(false) {
+        if self.is_default.unwrap_or(false)
+            && self.is_autoselect.is_some()
+            && !self.is_autoselect.unwrap()
+        {
             return Err(Error::custom(format!(
-                "If `DEFAULT` is true, `AUTOSELECT` has to be true too, Default: {:?}, Autoselect: {:?}!",
+                "If `DEFAULT` is true, `AUTOSELECT` has to be true too, if present. Default: {:?}, Autoselect: {:?}!",
                 self.is_default, self.is_autoselect
             ))
             .to_string());
@@ -462,6 +465,26 @@ mod test {
     }
 
     generate_tests! {
+        {
+            ExtXMedia::builder()
+                .media_type(MediaType::Audio)
+                .group_id("audio")
+                .language("eng")
+                .name("English")
+                .is_default(true)
+                .uri("eng/prog_index.m3u8")
+                .build()
+                .unwrap(),
+            concat!(
+                "#EXT-X-MEDIA:",
+                "TYPE=AUDIO,",
+                "URI=\"eng/prog_index.m3u8\",",
+                "GROUP-ID=\"audio\",",
+                "LANGUAGE=\"eng\",",
+                "NAME=\"English\",",
+                "DEFAULT=YES",
+            )
+        },
         {
             ExtXMedia::builder()
                 .media_type(MediaType::Audio)


### PR DESCRIPTION
In 4.3.4.1. EXT-X-MEDIA section about AUTOSELECT is written

   If the AUTOSELECT attribute is present, its value MUST be YES if
   the value of the DEFAULT attribute is YES.

That means, that if DEFAULT is YES and AUTOSELECT is *not present*, it
ok.

Before the patch, incorrect error is emitted

  If `DEFAULT` is true, `AUTOSELECT` has to be true too, Default:
  Some(true), Autoselect: None!

Signed-off-by: Nikola Pajkovsky <nikola.pajkovsky@livesporttv.cz>